### PR TITLE
Fix Prev/Next buttons when reading oldest items first

### DIFF
--- a/qml/ttrss/tinytinyrss.js
+++ b/qml/ttrss/tinytinyrss.js
@@ -860,7 +860,7 @@ function getFeedItems(feedId, inverse) {
 }
 
 function getNextFeedId(feedId, articleId) {
-    var items = getFeedItems(feedId)
+    var items = getFeedItems(feedId, settings.feeditemsOrder === 1)
 
     for(var feeditem = 0; feeditem < items.length; feeditem++) {
         if (items[feeditem].id == articleId) {
@@ -872,7 +872,7 @@ function getNextFeedId(feedId, articleId) {
 }
 
 function getPreviousFeedId(feedId, articleId) {
-    var items = getFeedItems(feedId)
+    var items = getFeedItems(feedId, settings.feeditemsOrder === 1)
 
     for(var feeditem = 0; feeditem < items.length; feeditem++) {
         if (items[feeditem].id == articleId) {


### PR DESCRIPTION
The toolbar buttons for jumping to the next/previous items were
inverted, when ttrss was configured to read oldest articles first.
