### PR TITLE
Support ico image type in emulator

### DIFF
--- a/rpm/harbour-ttrss-cnlpete.spec
+++ b/rpm/harbour-ttrss-cnlpete.spec
@@ -21,6 +21,7 @@ URL:        http://ttrss.cnlpete.de/
 Source0:    %{name}-%{version}.tar.bz2
 Source100:  harbour-ttrss-cnlpete.yaml
 Requires:   sailfishsilica-qt5 >= 0.10.9
+Requires:   qt5-plugin-imageformat-ico
 BuildRequires:  pkgconfig(Qt5Quick)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Core)

--- a/rpm/harbour-ttrss-cnlpete.yaml
+++ b/rpm/harbour-ttrss-cnlpete.yaml
@@ -20,6 +20,7 @@ PkgConfigBR:
 - sailfishapp >= 0.0.10
 Requires:
 - sailfishsilica-qt5 >= 0.10.9
+- qt5-plugin-imageformat-ico
 Files:
 - '%{_bindir}'
 - '%{_datadir}/%{name}/qml'


### PR DESCRIPTION
No more `Unsupported image format` errors.
