### PR TITLE
fix #168 for Latvian special chars and numerical entities visibility in excerpt

### DIFF
--- a/qml/ttrss/models/htmlentities.js
+++ b/qml/ttrss/models/htmlentities.js
@@ -136,6 +136,8 @@ function get_html_translation_table (table, quote_style) {
         entities['253'] = '&yacute;';
         entities['254'] = '&thorn;';
         entities['255'] = '&yuml;';
+        entities['352'] = '&Scaron;';
+        entities['353'] = '&scaron;';
     }
     if (useQuoteStyle !== 'ENT_NOQUOTES') {
         entities['34'] = '&quot;';
@@ -190,6 +192,10 @@ function html_entity_decode (string, quote_style) {
         tmp_str = tmp_str.split(entity).join(symbol);
     }
     tmp_str = tmp_str.split('&#039;').join("'");
-
+    //decode numeric html entities
+    tmp_str = tmp_str.replace(/&#([0-9]{1,3});/gi, function(match, numStr) {
+        var num = parseInt(numStr, 10);
+        return String.fromCharCode(num);
+    });
     return tmp_str;
 }


### PR DESCRIPTION
One possible solution for #168 displaying Latvian special chars and other numerical HTML entities in excerpts: 

* Added to hashmap named entity for Šš, `&Scaron;&scaron;` in `get_html_translation_table`
* Added decoding of numerical entities at `html_entity_decode`

It is also possible to make the chars visible by changing subtitle type in `FeedItemDelegate.qml` from `textFormat: Text.StyledText` to `textFormat: Text.RichText`, but as RichText does not support truncating then full article text was visible in the list which was not suitable as solution for excerpts, but explains why full articles displayed the special chars. 